### PR TITLE
feat: implement a CLI to run multiple JSON files

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Replay is a library which provides an API to replay and stringify recordings created using Chrome DevTools Recorder](https://developer.chrome.com/docs/devtools/recorder/)",
   "main": "lib/main.js",
   "types": "lib/main.d.ts",
+  "bin": "./lib/cli.js",
   "repository": "github:puppeteer/replay",
   "directories": {
     "doc": "docs"
@@ -58,5 +59,13 @@
     "typedoc": "0.22.13",
     "typedoc-plugin-markdown": "3.11.14",
     "typescript": "4.6.2"
+  },
+  "peerDependencies": {
+    "puppeteer": "^13.5.1"
+  },
+  "peerDependenciesMeta": {
+    "puppeteer": {
+      "optional": true
+    }
   }
 }

--- a/src/CLIUtils.ts
+++ b/src/CLIUtils.ts
@@ -1,0 +1,43 @@
+/**
+    Copyright 2022 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import { parse, createRunner } from './main.js';
+import { readFileSync } from 'fs';
+
+export function getFilenames(argv: string[]) {
+  return argv.slice(2);
+}
+
+export async function runFiles(
+  files: string[],
+  opts = { log: false }
+): Promise<boolean> {
+  for (const file of files) {
+    opts.log && console.log(`Running ${file}...`);
+    try {
+      const content = readFileSync(file, 'utf-8');
+      const object = JSON.parse(content);
+      const recording = parse(object);
+      const runner = await createRunner(recording);
+      await runner.run();
+      opts.log && console.log(`Finished running ${file}`);
+    } catch (err) {
+      opts.log && console.error(`Error running ${file}`, err);
+      return false;
+    }
+  }
+  return true;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+    Copyright 2022 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import { getFilenames, runFiles } from './CLIUtils.js';
+
+const recordings = getFilenames(process.argv);
+if (!recordings.length) {
+  console.log(`Usage: replay filename [filename...]`);
+}
+await runFiles(recordings, {
+  log: true,
+});

--- a/test/cli_test.ts
+++ b/test/cli_test.ts
@@ -1,0 +1,45 @@
+/**
+    Copyright 2022 Google LLC
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+ */
+
+import { getFilenames, runFiles } from '../src/CLIUtils.js';
+import { assert } from 'chai';
+import path from 'path';
+import url from 'url';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+describe('cli', () => {
+  describe('getFilenames', () => {
+    it('extracts filenames from process.argv', () => {
+      assert.deepStrictEqual(getFilenames(['node', 'script.js']), []);
+      assert.deepStrictEqual(getFilenames(['node', 'script.js', 'file1']), [
+        'file1',
+      ]);
+      assert.deepStrictEqual(
+        getFilenames(['node', 'script.js', 'file1', 'file2', 'file3']),
+        ['file1', 'file2', 'file3']
+      );
+    });
+  });
+
+  describe('runFiles', () => {
+    it('is able to run successfully', async () => {
+      assert.isTrue(
+        await runFiles([path.join(__dirname, 'resources', 'replay.json')])
+      );
+    });
+  });
+});

--- a/test/resources/replay.json
+++ b/test/resources/replay.json
@@ -1,0 +1,9 @@
+{
+  "title": "wiki",
+  "steps": [
+    {
+      "type": "navigate",
+      "url": "https://www.wikipedia.org/"
+    }
+  ]
+}


### PR DESCRIPTION
This PR implements a basic CLI for running multiple JSON files. It also declares Puppeteer as an optional peer dependency. This PR does not include any public facing documentation yet as I would like to test the workflow once it's published to NPM,  iterate and write documentation. 