### PR TITLE
feat: allow headful run using PUPPETEER_HEADFUL=1

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ In your `package.json` add a new script to invoke the `replay` command:
 }
 ```
 
+**Note:** for the both CLI and `package.json` usage, you can set a `PUPPETEER_HEADFUL` environment variable in order to run "headful".
+
 Using [the replay lib API](/examples/replay-from-file-using-puppeteer/main.js):
 
 ```js

--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -75,7 +75,7 @@ export async function createRunner(
   if (!extension) {
     const { default: puppeteer } = await import('puppeteer');
     const browser = await puppeteer.launch({
-      headless: true,
+      headless: typeof process?.env?.PUPPETEER_HEADFUL !== 'undefined',
     });
     const page = await browser.newPage();
     extension = new PuppeteerRunnerOwningBrowserExtension(browser, page);


### PR DESCRIPTION
This is a very small change to allow the usage of `PUPPETEER_HEADFUL` environment variable to run "headful".

> It's a good idea to open an issue first for discussion.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR