### PR TITLE
chore: move helpers to bottom of stringify output

### DIFF
--- a/__snapshots__/stringify_test.ts.js
+++ b/__snapshots__/stringify_test.ts.js
@@ -7,6 +7,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await targetPage.goto("https://localhost/");
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -149,12 +156,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await targetPage.goto("https://localhost/");
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -170,6 +171,18 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await targetPage.emulateNetworkConditions({
+      offline: false,
+      downloadThroughput: 100,
+      uploadThroughput: 100,
+      latency: 999,
+    });
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -312,17 +325,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await targetPage.emulateNetworkConditions({
-      offline: false,
-      downloadThroughput: 100,
-      uploadThroughput: 100,
-      latency: 999,
-    });
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -338,148 +340,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
-  async function waitForSelectors(selectors, frame, options) {
-    for (const selector of selectors) {
-      try {
-        return await waitForSelector(selector, frame, options);
-      } catch (err) {
-        console.error(err);
-      }
-    }
-    throw new Error('Could not find element for selectors: ' + JSON.stringify(selectors));
-  }
-
-  async function scrollIntoViewIfNeeded(element, timeout) {
-    await waitForConnected(element, timeout);
-    const isInViewport = await element.isIntersectingViewport({threshold: 0});
-    if (isInViewport) {
-      return;
-    }
-    await element.evaluate(element => {
-      element.scrollIntoView({
-        block: 'center',
-        inline: 'center',
-        behavior: 'auto',
-      });
-    });
-    await waitForInViewport(element, timeout);
-  }
-
-  async function waitForConnected(element, timeout) {
-    await waitForFunction(async () => {
-      return await element.getProperty('isConnected');
-    }, timeout);
-  }
-
-  async function waitForInViewport(element, timeout) {
-    await waitForFunction(async () => {
-      return await element.isIntersectingViewport({threshold: 0});
-    }, timeout);
-  }
-
-  async function waitForSelector(selector, frame, options) {
-    if (!Array.isArray(selector)) {
-      selector = [selector];
-    }
-    if (!selector.length) {
-      throw new Error('Empty selector provided to waitForSelector');
-    }
-    let element = null;
-    for (let i = 0; i < selector.length; i++) {
-      const part = selector[i];
-      if (element) {
-        element = await element.waitForSelector(part, options);
-      } else {
-        element = await frame.waitForSelector(part, options);
-      }
-      if (!element) {
-        throw new Error('Could not find element: ' + selector.join('>>'));
-      }
-      if (i < selector.length - 1) {
-        element = (await element.evaluateHandle(el => el.shadowRoot ? el.shadowRoot : el)).asElement();
-      }
-    }
-    if (!element) {
-      throw new Error('Could not find element: ' + selector.join('|'));
-    }
-    return element;
-  }
-
-  async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
-      '==': (a, b) => a === b,
-      '>=': (a, b) => a >= b,
-      '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
-    await waitForFunction(async () => {
-      const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
-    }, timeout);
-  }
-
-  async function querySelectorsAll(selectors, frame) {
-    for (const selector of selectors) {
-      const result = await querySelectorAll(selector, frame);
-      if (result.length) {
-        return result;
-      }
-    }
-    return [];
-  }
-
-  async function querySelectorAll(selector, frame) {
-    if (!Array.isArray(selector)) {
-      selector = [selector];
-    }
-    if (!selector.length) {
-      throw new Error('Empty selector provided to querySelectorAll');
-    }
-    let elements = [];
-    for (let i = 0; i < selector.length; i++) {
-      const part = selector[i];
-      if (i === 0) {
-        elements = await frame.$$(part);
-      } else {
-        const tmpElements = elements;
-        elements = [];
-        for (const el of tmpElements) {
-          elements.push(...(await el.$$(part)));
-        }
-      }
-      if (elements.length === 0) {
-        return [];
-      }
-      if (i < selector.length - 1) {
-        const tmpElements = [];
-        for (const el of elements) {
-          const newEl = (await el.evaluateHandle(el => el.shadowRoot ? el.shadowRoot : el)).asElement();
-          if (newEl) {
-            tmpElements.push(newEl);
-          }
-        }
-        elements = tmpElements;
-      }
-    }
-    return elements;
-  }
-
-  async function waitForFunction(fn, timeout) {
-    let isActive = true;
-    setTimeout(() => {
-      isActive = false;
-    }, timeout);
-    while (isActive) {
-      const result = await fn();
-      if (result) {
-        return;
-      }
-      await new Promise(resolve => setTimeout(resolve, 100));
-    }
-    throw new Error('Timed out');
-  }
   {
     const target = await browser.waitForTarget(t => t.url() === "https://localhost/test", { timeout });
     const targetPage = await target.page();
@@ -495,18 +355,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   await browser.close();
-})();
-
-`;
-
-exports['stringify should use step and flow timeouts 1'] = `
-const puppeteer = require('puppeteer'); // v13.0.0 or later
-
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  const timeout = 10000;
-  page.setDefaultTimeout(timeout);
 
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
@@ -650,6 +498,19 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
+})();
+
+`;
+
+exports['stringify should use step and flow timeouts 1'] = `
+const puppeteer = require('puppeteer'); // v13.0.0 or later
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const timeout = 10000;
+  page.setDefaultTimeout(timeout);
+
   {
     const timeout = 20000;
     const target = await browser.waitForTarget(t => t.url() === "https://localhost/test", { timeout });
@@ -666,20 +527,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   await browser.close();
-})();
-
-`;
-
-exports[
-  'stringify should print the correct script if the step is within an iframe 1'
-] = `
-const puppeteer = require('puppeteer'); // v13.0.0 or later
-
-(async () => {
-  const browser = await puppeteer.launch();
-  const page = await browser.newPage();
-  const timeout = 5000;
-  page.setDefaultTimeout(timeout);
 
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
@@ -823,6 +670,21 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
+})();
+
+`;
+
+exports[
+  'stringify should print the correct script if the step is within an iframe 1'
+] = `
+const puppeteer = require('puppeteer'); // v13.0.0 or later
+
+(async () => {
+  const browser = await puppeteer.launch();
+  const page = await browser.newPage();
+  const timeout = 5000;
+  page.setDefaultTimeout(timeout);
+
   {
     const targetPage = page;
     let frame = targetPage.mainFrame();
@@ -839,6 +701,149 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   await browser.close();
+
+  async function waitForSelectors(selectors, frame, options) {
+    for (const selector of selectors) {
+      try {
+        return await waitForSelector(selector, frame, options);
+      } catch (err) {
+        console.error(err);
+      }
+    }
+    throw new Error('Could not find element for selectors: ' + JSON.stringify(selectors));
+  }
+
+  async function scrollIntoViewIfNeeded(element, timeout) {
+    await waitForConnected(element, timeout);
+    const isInViewport = await element.isIntersectingViewport({threshold: 0});
+    if (isInViewport) {
+      return;
+    }
+    await element.evaluate(element => {
+      element.scrollIntoView({
+        block: 'center',
+        inline: 'center',
+        behavior: 'auto',
+      });
+    });
+    await waitForInViewport(element, timeout);
+  }
+
+  async function waitForConnected(element, timeout) {
+    await waitForFunction(async () => {
+      return await element.getProperty('isConnected');
+    }, timeout);
+  }
+
+  async function waitForInViewport(element, timeout) {
+    await waitForFunction(async () => {
+      return await element.isIntersectingViewport({threshold: 0});
+    }, timeout);
+  }
+
+  async function waitForSelector(selector, frame, options) {
+    if (!Array.isArray(selector)) {
+      selector = [selector];
+    }
+    if (!selector.length) {
+      throw new Error('Empty selector provided to waitForSelector');
+    }
+    let element = null;
+    for (let i = 0; i < selector.length; i++) {
+      const part = selector[i];
+      if (element) {
+        element = await element.waitForSelector(part, options);
+      } else {
+        element = await frame.waitForSelector(part, options);
+      }
+      if (!element) {
+        throw new Error('Could not find element: ' + selector.join('>>'));
+      }
+      if (i < selector.length - 1) {
+        element = (await element.evaluateHandle(el => el.shadowRoot ? el.shadowRoot : el)).asElement();
+      }
+    }
+    if (!element) {
+      throw new Error('Could not find element: ' + selector.join('|'));
+    }
+    return element;
+  }
+
+  async function waitForElement(step, frame, timeout) {
+    const count = step.count || 1;
+    const operator = step.operator || '>=';
+    const comp = {
+      '==': (a, b) => a === b,
+      '>=': (a, b) => a >= b,
+      '<=': (a, b) => a <= b,
+    };
+    const compFn = comp[operator];
+    await waitForFunction(async () => {
+      const elements = await querySelectorsAll(step.selectors, frame);
+      return compFn(elements.length, count);
+    }, timeout);
+  }
+
+  async function querySelectorsAll(selectors, frame) {
+    for (const selector of selectors) {
+      const result = await querySelectorAll(selector, frame);
+      if (result.length) {
+        return result;
+      }
+    }
+    return [];
+  }
+
+  async function querySelectorAll(selector, frame) {
+    if (!Array.isArray(selector)) {
+      selector = [selector];
+    }
+    if (!selector.length) {
+      throw new Error('Empty selector provided to querySelectorAll');
+    }
+    let elements = [];
+    for (let i = 0; i < selector.length; i++) {
+      const part = selector[i];
+      if (i === 0) {
+        elements = await frame.$$(part);
+      } else {
+        const tmpElements = elements;
+        elements = [];
+        for (const el of tmpElements) {
+          elements.push(...(await el.$$(part)));
+        }
+      }
+      if (elements.length === 0) {
+        return [];
+      }
+      if (i < selector.length - 1) {
+        const tmpElements = [];
+        for (const el of elements) {
+          const newEl = (await el.evaluateHandle(el => el.shadowRoot ? el.shadowRoot : el)).asElement();
+          if (newEl) {
+            tmpElements.push(newEl);
+          }
+        }
+        elements = tmpElements;
+      }
+    }
+    return elements;
+  }
+
+  async function waitForFunction(fn, timeout) {
+    let isActive = true;
+    setTimeout(() => {
+      isActive = false;
+    }, timeout);
+    while (isActive) {
+      const result = await fn();
+      if (result) {
+        return;
+      }
+      await new Promise(resolve => setTimeout(resolve, 100));
+    }
+    throw new Error('Timed out');
+  }
 })();
 
 `;
@@ -852,6 +857,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await targetPage.keyboard.down("E");
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -994,12 +1006,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await targetPage.keyboard.down("E");
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -1013,6 +1019,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await targetPage.keyboard.up("E");
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -1155,12 +1168,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await targetPage.keyboard.up("E");
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -1174,6 +1181,19 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    const element = await waitForSelectors(["body > div:nth-child(1)"], targetPage, { timeout, visible: true });
+    await scrollIntoViewIfNeeded(element, timeout);
+    await element.evaluate((el, x, y) => { el.scrollTop = y; el.scrollLeft = x; }, 0, 40);
+  }
+  {
+    const targetPage = page;
+    await targetPage.evaluate((x, y) => { window.scroll(x, y); }, 40, 40)
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -1316,18 +1336,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    const element = await waitForSelectors(["body > div:nth-child(1)"], targetPage, { timeout, visible: true });
-    await scrollIntoViewIfNeeded(element, timeout);
-    await element.evaluate((el, x, y) => { el.scrollTop = y; el.scrollLeft = x; }, 0, 40);
-  }
-  {
-    const targetPage = page;
-    await targetPage.evaluate((x, y) => { window.scroll(x, y); }, 40, 40)
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -1343,6 +1351,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await waitForElement({"type":"waitForElement","selectors":["body > div:nth-child(1)"]}, targetPage, timeout);
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -1485,12 +1500,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await waitForElement({"type":"waitForElement","selectors":["body > div:nth-child(1)"]}, targetPage, timeout);
-  }
-
-  await browser.close();
 })();
 
 `;
@@ -1506,6 +1515,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   const timeout = 5000;
   page.setDefaultTimeout(timeout);
 
+  {
+    const targetPage = page;
+    await targetPage.waitForFunction("1 + 2", { timeout });
+  }
+
+  await browser.close();
+
   async function waitForSelectors(selectors, frame, options) {
     for (const selector of selectors) {
       try {
@@ -1648,12 +1664,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-  {
-    const targetPage = page;
-    await targetPage.waitForFunction("1 + 2", { timeout });
-  }
-
-  await browser.close();
 })();
 
 `;

--- a/src/PuppeteerStringifyExtension.ts
+++ b/src/PuppeteerStringifyExtension.ts
@@ -54,16 +54,16 @@ export class PuppeteerStringifyExtension extends StringifyExtension {
     out.appendLine(`const timeout = ${flow.timeout || defaultTimeout};`);
     out.appendLine('page.setDefaultTimeout(timeout);');
     out.appendLine('');
-
-    for (const line of helpers.split('\n')) {
-      out.appendLine(line);
-    }
   }
 
   async afterAllSteps(out: LineWriter, flow: UserFlow) {
     out.appendLine('');
-    out.appendLine('await browser.close();').endBlock();
-    out.appendLine('})();');
+    out.appendLine('await browser.close();');
+    out.appendLine('');
+    for (const line of helpers.split('\n')) {
+      out.appendLine(line);
+    }
+    out.endBlock().appendLine('})();');
   }
 
   async stringifyStep(out: LineWriter, step: Step, flow: UserFlow) {


### PR DESCRIPTION
Whenever I've looked at the pptr output I gotta scroll past the 150 lines of boilerplate at the top of the file to get to the actual steps. Since function hoisting is automatic and easy, there's no reason we can't move 'em down to prioritize showing the important stuff.

wdyt?

cc @adamraine