### PR TITLE
Make cjs the main package entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@puppeteer/replay",
   "version": "0.4.0",
   "description": "Replay is a library which provides an API to replay and stringify recordings created using Chrome DevTools Recorder](https://developer.chrome.com/docs/devtools/recorder/)",
-  "main": "lib/main.js",
+  "main": "lib/cjs/main.cjs",
   "types": "lib/main.d.ts",
   "bin": "lib/cli.js",
   "exports": {


### PR DESCRIPTION
https://nodejs.org/docs/latest-v12.x/api/packages.html#packages_main

`"main"` is used as the entry point whenever a package is imported via `require` so it should point to the CJS entry point. 

This isn't normally an issue because `"exports"` will override `"main"`. However, Jest doesn't appear to have this behavior, and it will use `"main"` as the default entry point.

Possibly related https://github.com/puppeteer/replay/issues/188