### PR TITLE
chore: spreading all SchemaUtils exports

### DIFF
--- a/src/SchemaUtils.ts
+++ b/src/SchemaUtils.ts
@@ -48,7 +48,7 @@ export function assertAllStepTypesAreHandled(s: Step): never {
   throw new Error(`Unknown step type: ${s.type}`);
 }
 
-export const typeableInputTypes = new Set([
+export const typeableInputTypes: ReadonlySet<string> = new Set([
   'textarea',
   'text',
   'url',
@@ -59,12 +59,16 @@ export const typeableInputTypes = new Set([
   'email',
 ]);
 
-export const pointerDeviceTypes = new Set(['mouse', 'pen', 'touch']);
+export const pointerDeviceTypes: ReadonlySet<string> = new Set([
+  'mouse',
+  'pen',
+  'touch',
+]);
 
-export const mouseButtonMap = new Map<
+export const mouseButtonMap: ReadonlyMap<
   string,
   'left' | 'middle' | 'right' | 'back' | 'forward'
->([
+> = new Map([
   ['primary', 'left'],
   ['auxiliary', 'middle'],
   ['secondary', 'right'],

--- a/src/main.ts
+++ b/src/main.ts
@@ -19,7 +19,7 @@
  */
 export * from './Schema.js';
 export * as Schema from './Schema.js';
-export { parse, parseStep } from './SchemaUtils.js';
+export * from './SchemaUtils.js';
 export { StringifyExtension } from './StringifyExtension.js';
 export { stringify, stringifyStep, StringifyOptions } from './stringify.js';
 export { LineWriter } from './LineWriter.js';


### PR DESCRIPTION
Spreading all SchemaUtils.js exports and using read-only types on exported objects to prevent mutation.