### PR TITLE
chore: allow puppeteer v15 and v16 as peerDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "puppeteer": "16.1.0"
+        "puppeteer": "^15.3.1 || ^16.1.0"
       },
       "peerDependenciesMeta": {
         "puppeteer": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "node": ">=14"
       },
       "peerDependencies": {
-        "puppeteer": "^15.3.1 || ^16.1.0"
+        "puppeteer": ">=15.3.1"
       },
       "peerDependenciesMeta": {
         "puppeteer": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "4.6.4"
   },
   "peerDependencies": {
-    "puppeteer": "^15.3.1 || ^16.1.0"
+    "puppeteer": ">=15.3.1"
   },
   "peerDependenciesMeta": {
     "puppeteer": {

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "typescript": "4.6.4"
   },
   "peerDependencies": {
-    "puppeteer": "^15.3.1"
+    "puppeteer": "^15.3.1 || ^16.1.0"
   },
   "peerDependenciesMeta": {
     "puppeteer": {


### PR DESCRIPTION
Hi there!

Attempting to install puppeteer v16 together with this package results in a conflict, see the reproducer below.
Looking at recent PRs (https://github.com/puppeteer/replay/pull/239 / https://github.com/puppeteer/replay/pull/248), this package seems to be compatible with v16, and the missed update of the `peerDependencies` spec was likely an oversight.
This PR is adding the v16 version spec from the `devDependencies` as a secondary version to the `peerDependencies`, which fixes the conflict.

(Let me know if you want a dedicated issue for the bug. The fix seemed too trivial to bother creating an issue for.)

<details>
<summary> reproducer </summary>

package.json:
```json
{
  "dependencies": {
    "puppeteer": "^16.1.0",
    "@puppeteer/replay": "^0.6.1"
  }
}
``` 

```bash
$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @puppeteer/replay@0.6.1
npm ERR! Found: puppeteer@16.1.0
npm ERR! node_modules/puppeteer
npm ERR!   puppeteer@"^16.1.0" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peerOptional puppeteer@"^15.3.1" from @puppeteer/replay@0.6.1
npm ERR! node_modules/@puppeteer/replay
npm ERR!   @puppeteer/replay@"^0.6.1" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: puppeteer@15.5.0
npm ERR! node_modules/puppeteer
npm ERR!   peerOptional puppeteer@"^15.3.1" from @puppeteer/replay@0.6.1
npm ERR!   node_modules/@puppeteer/replay
npm ERR!     @puppeteer/replay@"^0.6.1" from the root project
npm ERR! 
```

Using the branch of this PR works (sort of, the build artifacts are missing, but the general installation works):

```json
{
  "dependencies": {
    "puppeteer": "^16.1.0",
    "@puppeteer/replay": "github:das7pad/replay#allow-v16-as-peer"
  }
}
```

```bash
$ npm install

added 78 packages, and audited 79 packages in 2m

10 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```

</details>

NPM docs for specifying multiple version ranges: https://docs.npmjs.com/cli/v8/configuring-npm/package-json#dependencies