### PR TITLE
fix: Puppeteer stringified button click type

### DIFF
--- a/__snapshots__/stringify.test.ts.js
+++ b/__snapshots__/stringify.test.ts.js
@@ -156,7 +156,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -325,7 +328,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -498,7 +504,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -670,7 +679,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -844,7 +856,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -1006,7 +1021,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -1168,7 +1186,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -1336,7 +1357,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -1500,7 +1524,10 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;
 
@@ -1664,6 +1691,9 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     }
     throw new Error('Timed out');
   }
-})();
+})().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
 
 `;

--- a/src/PuppeteerStringifyExtension.ts
+++ b/src/PuppeteerStringifyExtension.ts
@@ -63,7 +63,10 @@ export class PuppeteerStringifyExtension extends StringifyExtension {
     for (const line of helpers.split('\n')) {
       out.appendLine(line);
     }
-    out.endBlock().appendLine('})();');
+    out.endBlock().appendLine('})().catch(err => {').startBlock();
+    out.appendLine('console.error(err);');
+    out.appendLine('process.exit(1);');
+    out.endBlock().appendLine('});');
   }
 
   override async stringifyStep(out: LineWriter, step: Step, flow: UserFlow) {
@@ -145,7 +148,7 @@ export class PuppeteerStringifyExtension extends StringifyExtension {
       out.appendLine(`  delay: ${step.duration},`);
     }
     if (step.button) {
-      out.appendLine(`  button: ${mouseButtonMap.get(step.button)},`);
+      out.appendLine(`  button: '${mouseButtonMap.get(step.button)}',`);
     }
     out.appendLine('  offset: {');
     out.appendLine(`    x: ${step.offsetX},`);
@@ -159,7 +162,7 @@ export class PuppeteerStringifyExtension extends StringifyExtension {
     out.appendLine('await element.click({');
     out.appendLine(`  clickCount: 2,`);
     if (step.button) {
-      out.appendLine(`  button: ${mouseButtonMap.get(step.button)},`);
+      out.appendLine(`  button: '${mouseButtonMap.get(step.button)}',`);
     }
     out.appendLine('  offset: {');
     out.appendLine(`    x: ${step.offsetX},`);


### PR DESCRIPTION
I noticed there were missing quotes around the click type in the puppeteer stringify extension.
