### PR TITLE
chore: turn off warn for not used vars

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -18,7 +18,7 @@ module.exports = {
     'valid-jsdoc': 0, // Figure jsdoc once we look into documentation.
     'tsdoc/syntax': 'warn',
     'no-unused-vars': 'off',
-    '@typescript-eslint/no-unused-vars': 'warn',
+    '@typescript-eslint/no-unused-vars': 'off',
   },
   ignorePatterns: ['third_party/**/*'],
 };


### PR DESCRIPTION
We have some unused vars for documentation purposes but
the emitted warnings get picked up by GitHub and shown in
the diff view in pull requests making it impossible to review.
Although we could suppress only those specific warnings, I think
the warning is not that useful anyway so that we can turn all of
them off.