### PR TITLE
fix: (waitForFunction) clearing timeout when callback function returns a truthy value

### DIFF
--- a/__snapshots__/lighthouse-e2e.test.ts.js
+++ b/__snapshots__/lighthouse-e2e.test.ts.js
@@ -227,12 +227,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));

--- a/__snapshots__/stringify.test.ts.js
+++ b/__snapshots__/stringify.test.ts.js
@@ -144,12 +144,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -316,12 +317,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -492,12 +494,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -667,12 +670,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -844,12 +848,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -1009,12 +1014,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -1174,12 +1180,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -1345,12 +1352,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -1512,12 +1520,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));
@@ -1679,12 +1688,13 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
 
   async function waitForFunction(fn, timeout) {
     let isActive = true;
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       isActive = false;
     }, timeout);
     while (isActive) {
       const result = await fn();
       if (result) {
+        clearTimeout(timeoutId);
         return;
       }
       await new Promise(resolve => setTimeout(resolve, 100));

--- a/src/PuppeteerRunnerExtension.ts
+++ b/src/PuppeteerRunnerExtension.ts
@@ -636,12 +636,13 @@ async function waitForFunction(
   timeout: number
 ): Promise<void> {
   let isActive = true;
-  setTimeout(() => {
+  const timeoutId = setTimeout(() => {
     isActive = false;
   }, timeout);
   while (isActive) {
     const result = await fn();
     if (result) {
+      clearTimeout(timeoutId);
       return;
     }
     await new Promise((resolve) => setTimeout(resolve, 100));

--- a/src/PuppeteerStringifyExtension.ts
+++ b/src/PuppeteerStringifyExtension.ts
@@ -448,12 +448,13 @@ async function querySelectorAll(selector, frame) {
 
 async function waitForFunction(fn, timeout) {
   let isActive = true;
-  setTimeout(() => {
+  const timeoutId = setTimeout(() => {
     isActive = false;
   }, timeout);
   while (isActive) {
     const result = await fn();
     if (result) {
+      clearTimeout(timeoutId);
       return;
     }
     await new Promise(resolve => setTimeout(resolve, 100));


### PR DESCRIPTION
An uncleared timeout results in an open handle that prevents the process from exiting.

Running the tests demonstrates this clearly-

before-

![before](https://user-images.githubusercontent.com/16611980/187990795-929f44e7-6bd1-448e-932f-17a3f4254845.gif)

after-

![after](https://user-images.githubusercontent.com/16611980/187990886-738fa318-5cbd-4ec3-bc11-e43931d71002.gif)

