### PR TITLE
chore: add id-token permissions to scorecard-action

### DIFF
--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -19,6 +19,8 @@ jobs:
       security-events: write
       actions: read
       contents: read
+      # Needed to access OIDC token.
+      id-token: write
 
     steps:
       - name: 'Checkout code'


### PR DESCRIPTION
See https://github.com/ossf/scorecard-action/issues/900

Example failure with scorecard-action@2 https://github.com/puppeteer/replay/actions/runs/3060651741/jobs/4939423471