### PR TITLE
core(lighthouse): use fewer steps in e2e tests

### DIFF
--- a/__snapshots__/lighthouse-e2e.test.ts.js
+++ b/__snapshots__/lighthouse-e2e.test.ts.js
@@ -66,32 +66,6 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
     await Promise.all(promises);
   }
   await lhFlow.endNavigation();
-  await lhFlow.startTimespan();
-  {
-    const targetPage = page;
-    await scrollIntoViewIfNeeded(["#test"], targetPage, timeout);
-    const element = await waitForSelectors(["#test"], targetPage, { timeout, visible: true });
-    await element.click({
-      button: 'left',
-      offset: {
-        x: 1,
-        y: 1,
-      },
-    });
-  }
-  {
-    const targetPage = page;
-    await scrollIntoViewIfNeeded(["#test"], targetPage, timeout);
-    const element = await waitForSelectors(["#test"], targetPage, { timeout, visible: true });
-    await element.click({
-      button: 'left',
-      offset: {
-        x: 1,
-        y: 1,
-      },
-    });
-  }
-  await lhFlow.endTimespan();
   const lhFlowReport = await lhFlow.generateReport();
   fs.writeFileSync(__dirname + '/flow.report.html', lhFlowReport)
 

--- a/test/lighthouse/lighthouse-e2e.test.ts
+++ b/test/lighthouse/lighthouse-e2e.test.ts
@@ -155,20 +155,6 @@ describe('Lighthouse user flow', function () {
                 },
               ],
             },
-            {
-              type: StepType.Click,
-              button: 'primary',
-              selectors: ['#test'],
-              offsetX: 1,
-              offsetY: 1,
-            },
-            {
-              type: StepType.Click,
-              button: 'primary',
-              selectors: ['#test'],
-              offsetX: 1,
-              offsetY: 1,
-            },
           ],
         };
 
@@ -177,7 +163,7 @@ describe('Lighthouse user flow', function () {
         assert.equal(flowResult.name, desktopReplayJson.title);
         assert.deepStrictEqual(
           flowResult.steps.map((step) => step.lhr.gatherMode),
-          ['navigation', 'timespan', 'navigation', 'timespan']
+          ['navigation', 'timespan', 'navigation']
         );
 
         for (const { lhr } of flowResult.steps as Array<{ lhr: Result }>) {


### PR DESCRIPTION
Part of #344 

The final timespan step doesn't add much value to the e2e test runner so I think it's fine to remove. Reduces the length of each e2e test from ~33s to ~26s on my Macbook.