### PR TITLE
feat: allow the runner to run beforeAll/afterAll hooks

### DIFF
--- a/src/Runner.ts
+++ b/src/Runner.ts
@@ -48,6 +48,14 @@ export class Runner {
     this.#flow = flow;
   }
 
+  async runBeforeAllSteps(flow?: UserFlow): Promise<void> {
+    await this.#extension.beforeAllSteps?.(flow);
+  }
+
+  async runAfterAllSteps(flow?: UserFlow): Promise<void> {
+    await this.#extension.afterAllSteps?.(flow);
+  }
+
   /**
    * Runs the provided `step` with `beforeEachStep` and `afterEachStep` hooks.
    * Parameters from the `flow` apply if the `flow` is set.

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -817,6 +817,12 @@ describe('Runner', () => {
       extension.getLog(),
       'beforeAll,beforeStep0,runStep0,afterStep0,afterAll'
     );
+    await runner.runBeforeAllSteps();
+    await runner.runAfterAllSteps();
+    assert.strictEqual(
+      extension.getLog(),
+      'beforeAll,beforeStep0,runStep0,afterStep0,afterAll,beforeAll,afterAll'
+    );
   });
 
   it('should record interactions with OOPIFs', async () => {


### PR DESCRIPTION
It's useful if you want to combine these hooks with custom runStep invocations.