### PR TITLE
docs: move test expectations for the everything test

### DIFF
--- a/test/everything.test.ts
+++ b/test/everything.test.ts
@@ -44,15 +44,12 @@ async function createServers() {
 }
 
 // Note: not using snapshots to make sure all tests result in the same log.
-const expectedLog = `window dimensions 900x700
-click targetId=button button=0 value=
-click targetId=button button=0 value=
-dblclick targetId=button button=0 value=
-change targetId=input button=undefined value=test
-change targetId=input-prefilled button=undefined value=testSuffix
-contextmenu targetId=input button=2 value=test
-mouseenter targetId=hover button=0 value=
-change targetId=select button=undefined value=optionB`;
+const expectedLog = (
+  await fs.readFile(
+    path.join(__dirname, 'resources', 'everything.expected.txt'),
+    'utf-8'
+  )
+).trim();
 
 describe('Everything', () => {
   let browser: puppeteer.Browser;

--- a/test/resources/everything.expected.txt
+++ b/test/resources/everything.expected.txt
@@ -1,0 +1,9 @@
+window dimensions 900x700
+click targetId=button button=0 value=
+click targetId=button button=0 value=
+dblclick targetId=button button=0 value=
+change targetId=input button=undefined value=test
+change targetId=input-prefilled button=undefined value=testSuffix
+contextmenu targetId=input button=2 value=test
+mouseenter targetId=hover button=0 value=
+change targetId=select button=undefined value=optionB


### PR DESCRIPTION
This makes it easier for the integrations to consume the test file, the test recording and the expected results. 