### PR TITLE
feat: expose getSelectorType

### DIFF
--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -19,6 +19,13 @@ export type Pattern = string;
 export type Selector = string | string[];
 export type FrameSelector = number[];
 
+export enum SelectorType {
+  CSS = 'css',
+  ARIA = 'aria',
+  Text = 'text',
+  XPath = 'xpath',
+}
+
 export enum StepType {
   Change = 'change',
   Click = 'click',

--- a/src/SchemaUtils.ts
+++ b/src/SchemaUtils.ts
@@ -14,7 +14,7 @@
     limitations under the License.
  */
 
-import type {
+import {
   AssertedEvent,
   BaseStep,
   ChangeStep,
@@ -32,6 +32,7 @@ import type {
   NavigateStep,
   ScrollStep,
   Selector,
+  SelectorType,
   SetViewportStep,
   Step,
   StepWithFrame,
@@ -568,4 +569,20 @@ export function parse(data: unknown): UserFlow {
         : undefined,
     steps: parseSteps(data.steps),
   });
+}
+
+/**
+ * Detects what type of a selector the string contains. For example,
+ * `aria/Label` is a SelectorType.ARIA.
+ *
+ * Note that CSS selectors are special and usually don't require a prefix,
+ * therefore, SelectorType.CSS is the default type if other types didn't match.
+ */
+export function getSelectorType(selector: string): SelectorType {
+  for (const value of Object.values(SelectorType)) {
+    if (selector.startsWith(`${value}/`)) {
+      return value;
+    }
+  }
+  return SelectorType.CSS;
 }

--- a/test/SchemaUtils.test.ts
+++ b/test/SchemaUtils.test.ts
@@ -14,8 +14,8 @@
     limitations under the License.
  */
 
-import { parse } from '../src/SchemaUtils.js';
-import { AssertedEventType, StepType } from '../src/Schema.js';
+import { parse, getSelectorType } from '../src/SchemaUtils.js';
+import { AssertedEventType, SelectorType, StepType } from '../src/Schema.js';
 import { assert } from 'chai';
 
 describe('SchemaUtils', () => {
@@ -722,7 +722,7 @@ describe('SchemaUtils', () => {
       );
     });
 
-    it('should handle wrong input with erros', () => {
+    it('should handle wrong input with errors', () => {
       const testCases = [
         {
           input: {},
@@ -766,6 +766,16 @@ describe('SchemaUtils', () => {
       for (const testCase of testCases) {
         assert.throws(() => parse(testCase.input), testCase.error);
       }
+    });
+  });
+
+  describe('Selectors', () => {
+    it('should detect selector types', () => {
+      assert.strictEqual(getSelectorType('css/.cls'), SelectorType.CSS);
+      assert.strictEqual(getSelectorType('.cls'), SelectorType.CSS);
+      assert.strictEqual(getSelectorType('aria/Text'), SelectorType.ARIA);
+      assert.strictEqual(getSelectorType('text/Text'), SelectorType.Text);
+      assert.strictEqual(getSelectorType('xpath///div'), SelectorType.XPath);
     });
   });
 });


### PR DESCRIPTION
Exposes an enum of SelectorTypes we support and
allows getting a type from a string.