### PR TITLE
feat: add `visible`, `properties`, and `attributes` to `waitForElement`

### DIFF
--- a/__snapshots__/lighthouse.test.ts.js
+++ b/__snapshots__/lighthouse.test.ts.js
@@ -164,17 +164,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 

--- a/__snapshots__/stringify.test.ts.js
+++ b/__snapshots__/stringify.test.ts.js
@@ -88,17 +88,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -302,17 +353,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -524,17 +626,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -745,17 +898,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -968,17 +1172,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -1175,17 +1430,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -1382,17 +1688,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -1599,17 +1956,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -1813,17 +2221,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 
@@ -2022,17 +2481,68 @@ const puppeteer = require('puppeteer'); // v13.0.0 or later
   }
 
   async function waitForElement(step, frame, timeout) {
-    const count = step.count || 1;
-    const operator = step.operator || '>=';
-    const comp = {
+    const {
+      count = 1,
+      operator = '>=',
+      visible = true,
+      properties,
+      attributes,
+    } = step;
+    const compFn = {
       '==': (a, b) => a === b,
       '>=': (a, b) => a >= b,
       '<=': (a, b) => a <= b,
-    };
-    const compFn = comp[operator];
+    }[operator];
     await waitForFunction(async () => {
       const elements = await querySelectorsAll(step.selectors, frame);
-      return compFn(elements.length, count);
+      let result = compFn(elements.length, count);
+      const elementsHandle = await frame.evaluateHandle((...elements) => {
+        return elements;
+      }, ...elements);
+      await Promise.all(elements.map((element) => element.dispose()));
+      if (result && (properties || attributes)) {
+        result = await elementsHandle.evaluate(
+          (elements, properties, attributes) => {
+            for (const element of elements) {
+              if (attributes) {
+                for (const [name, value] of Object.entries(attributes)) {
+                  if (element.getAttribute(name) !== value) {
+                    return false;
+                  }
+                }
+              }
+              if (properties) {
+                if (!isDeepMatch(properties, element)) {
+                  return false;
+                }
+              }
+            }
+            return true;
+
+            function isDeepMatch(a, b) {
+              if (a === b) {
+                return true;
+              }
+              if ((a && !b) || (!a && b)) {
+                return false;
+              }
+              if (!(a instanceof Object) || !(b instanceof Object)) {
+                return false;
+              }
+              for (const [key, value] of Object.entries(a)) {
+                if (!isDeepMatch(value, b[key])) {
+                  return false;
+                }
+              }
+              return true;
+            }
+          },
+          properties,
+          attributes
+        );
+      }
+      await elementsHandle.dispose();
+      return result === visible;
     }, timeout);
   }
 

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -14,6 +14,8 @@
     limitations under the License.
  */
 
+import { JSONSerializable, JSONValue } from './types.js';
+
 export type Target = string;
 export type Pattern = string;
 export type Selector = string | string[];
@@ -243,13 +245,30 @@ export type UserStep =
 export interface WaitForElementStep extends StepWithSelectors {
   type: StepType.WaitForElement;
   /**
-   * Defaults to '=='
+   * @defaultValue `'=='`
    */
   operator?: '>=' | '==' | '<=';
   /**
-   * Defaults to 1
+   * @defaultValue `1`
    */
   count?: number;
+  /**
+   * Whether to wait for elements matching this step to be hidden. This can be
+   * thought of as an inversion of this step.
+   *
+   * @defaultValue `true`
+   */
+  visible?: boolean;
+  /**
+   * Whether to also check the element(s) for the given properties.
+   */
+  properties?: Partial<JSONSerializable<HTMLElement>> & {
+    [key: string]: JSONValue;
+  };
+  /**
+   * Whether to also check the element(s) for the given attributes.
+   */
+  attributes?: { [name: string]: string };
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,24 @@
+export type ExcludeType<T, U> = {
+  [K in keyof T]-?: T[K] extends U ? K : never;
+}[keyof T];
+
+export type PickType<T, U> = Pick<T, ExcludeType<T, U>>;
+
+export type JSONValue =
+  | null
+  | string
+  | number
+  | boolean
+  | JSONObject
+  | JSONArray;
+
+export interface JSONObject {
+  [key: string]: JSONValue;
+}
+
+export type JSONArray = JSONValue[];
+
+export type JSONSerializable<Object extends object> = PickType<
+  Object,
+  JSONValue
+>;

--- a/test/resources/benchmark.json
+++ b/test/resources/benchmark.json
@@ -104,7 +104,14 @@
       "type": "waitForElement",
       "target": "main",
       "selectors": ["button"],
-      "count": 2
+      "count": 2,
+      "visible": true,
+      "properties": {
+        "value": ""
+      },
+      "attributes": {
+        "id": "button"
+      }
     },
     {
       "type": "change",

--- a/test/resources/shadow-dynamic.html
+++ b/test/resources/shadow-dynamic.html
@@ -19,7 +19,7 @@
     constructor() {
       super();
       const shadow = this.attachShadow({ mode: 'open' });
-      shadow.innerHTML = `<button id="test">Click me</button>`;
+      shadow.innerHTML = `<button id="test" class="unknown">Click me</button>`;
     }
   }
   customElements.define('custom-element', CustomElement);

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -645,43 +645,112 @@ describe('Runner', () => {
     );
   });
 
-  it('should be able to waitForElement', async () => {
-    const runner = await createRunner(
-      {
-        title: 'test',
-        steps: [
-          {
-            type: StepType.Navigate,
-            url: `${HTTP_PREFIX}/shadow-dynamic.html`,
-          },
-          {
-            type: StepType.WaitForElement,
-            selectors: [['custom-element', 'button']],
-          },
-          {
-            type: StepType.Click,
-            target: 'main',
-            selectors: [['custom-element', 'button']],
-            offsetX: 1,
-            offsetY: 1,
-          },
-          {
-            type: StepType.WaitForElement,
-            selectors: [['custom-element', 'button']],
-            operator: '>=',
-            count: 2,
-          },
-        ],
-      },
-      new PuppeteerRunnerExtension(browser, page)
-    );
-    await runner.run();
-    assert.strictEqual(
-      await page.evaluate(
-        () => document.querySelectorAll('custom-element').length
-      ),
-      2
-    );
+  describe('waitForElement', async () => {
+    it('should work', async () => {
+      const runner = await createRunner(
+        {
+          title: 'test',
+          steps: [
+            {
+              type: StepType.Navigate,
+              url: `${HTTP_PREFIX}/shadow-dynamic.html`,
+            },
+            {
+              type: StepType.WaitForElement,
+              selectors: [['custom-element', 'button']],
+            },
+          ],
+        },
+        new PuppeteerRunnerExtension(browser, page)
+      );
+      await runner.run();
+    });
+    it('should work with operators', async () => {
+      const runner = await createRunner(
+        {
+          title: 'test',
+          steps: [
+            {
+              type: StepType.Navigate,
+              url: `${HTTP_PREFIX}/shadow-dynamic.html`,
+            },
+            {
+              type: StepType.WaitForElement,
+              selectors: [['custom-element', 'button']],
+            },
+            {
+              type: StepType.Click,
+              target: 'main',
+              selectors: [['custom-element', 'button']],
+              offsetX: 1,
+              offsetY: 1,
+            },
+            {
+              type: StepType.WaitForElement,
+              selectors: [['custom-element', 'button']],
+              operator: '>=',
+              count: 2,
+            },
+          ],
+        },
+        new PuppeteerRunnerExtension(browser, page)
+      );
+      await runner.run();
+      assert.strictEqual(
+        await page.evaluate(
+          () => document.querySelectorAll('custom-element').length
+        ),
+        2
+      );
+    });
+    it('should work with hidden', async () => {
+      const runner = await createRunner(
+        {
+          title: 'test',
+          steps: [
+            {
+              type: StepType.Navigate,
+              url: `${HTTP_PREFIX}/shadow-dynamic.html`,
+            },
+            {
+              type: StepType.WaitForElement,
+              selectors: [['custom-element', 'button']],
+              visible: false,
+              properties: {
+                className: 'test',
+              },
+            },
+          ],
+        },
+        new PuppeteerRunnerExtension(browser, page)
+      );
+      await runner.run();
+    });
+    it('should work with properties and attributes', async () => {
+      const runner = await createRunner(
+        {
+          title: 'test',
+          steps: [
+            {
+              type: StepType.Navigate,
+              url: `${HTTP_PREFIX}/shadow-dynamic.html`,
+            },
+            {
+              type: StepType.WaitForElement,
+              selectors: [['custom-element', 'button']],
+              properties: {
+                className: 'unknown',
+              },
+              attributes: {
+                class: 'unknown',
+              },
+            },
+          ],
+        },
+        new PuppeteerRunnerExtension(browser, page)
+      );
+      await runner.run();
+    });
   });
 
   it('should be able to waitForExpression', async () => {


### PR DESCRIPTION
This PR adds three new properties:

 - `attributes` - This is a dictionary of strings that will match attributes of an element. This will always be a partial match.
For example, `”attributes”: {“value”: “125”}`.
 - `properties` - This is a JS record of JSON-serializable attributes that can be used to match an element’s JSON-serializable properties. This will be a sub-tree exact match. For arrays, order matters.
 - `visible` - This is a boolean value that inverts the match criteria.