### PR TITLE
feat: expose Lighthouse runner extension

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -38,4 +38,5 @@ export { PuppeteerRunnerOwningBrowserExtension } from './PuppeteerRunnerExtensio
 export { PuppeteerStringifyExtension } from './PuppeteerStringifyExtension.js';
 export { PuppeteerReplayStringifyExtension } from './PuppeteerReplayStringifyExtension.js';
 export { LighthouseStringifyExtension } from './lighthouse/LighthouseStringifyExtension.js';
+export { LighthouseRunnerExtension } from './lighthouse/LighthouseRunnerExtension.js';
 export * from './JSONUtils.js';


### PR DESCRIPTION
This was originally removed in https://github.com/puppeteer/replay/pull/337

Now that Lighthouse is a peer dependency we should be able to include it.