### PR TITLE
chore: upgrade Lighthouse to 10.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "eslint-config-prettier": "8.5.0",
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-tsdoc": "0.2.17",
-        "lighthouse": "^10.0.0",
+        "lighthouse": "^10.0.1",
         "mime": "3.0.0",
         "mocha": "10.1.0",
         "prettier": "2.7.1",
@@ -1489,7 +1489,8 @@
       "version": "0.0.1082910",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
       "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/diff": {
       "version": "5.0.0",
@@ -2714,9 +2715,9 @@
       }
     },
     "node_modules/lighthouse": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.0.0.tgz",
-      "integrity": "sha512-q9N2+1eeywdP81MEifePk+qTxZg9dLb0zajaWI8foqqxG8QD3eF+z6oVMx8VFglOAJMofw+AaXG10vmeoY+dBQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.0.1.tgz",
+      "integrity": "sha512-vxHggvQPAx5ousLosVzWHTPJ+MpVYee+ojiP0r0ewq8cWAvnzLb6M2EieeBfjjm87shRaj0BB2puC8gFztwXXw==",
       "dev": true,
       "dependencies": {
         "@sentry/node": "^6.17.4",
@@ -2738,7 +2739,6 @@
         "parse-cache-control": "1.0.1",
         "ps-list": "^8.0.0",
         "puppeteer-core": "^19.6.0",
-        "quibble": "github:connorjclark/quibble#fork",
         "robots-parser": "^3.0.0",
         "semver": "^5.3.0",
         "speedline-core": "^1.4.3",
@@ -2786,48 +2786,6 @@
       "resolved": "https://registry.npmjs.org/lighthouse-stack-packs/-/lighthouse-stack-packs-1.9.1.tgz",
       "integrity": "sha512-9prq6oMkVHz3GeCkphq4FHXXdj3M/WPiFWUvJAczLYV8j/oTxsgiHSPMqh1KVV11CP0VTxD40hFC0pDfXF+khQ==",
       "dev": true
-    },
-    "node_modules/lighthouse/node_modules/puppeteer-core": {
-      "version": "19.6.3",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-      "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
-      "dev": true,
-      "dependencies": {
-        "cross-fetch": "3.1.5",
-        "debug": "4.3.4",
-        "devtools-protocol": "0.0.1082910",
-        "extract-zip": "2.0.1",
-        "https-proxy-agent": "5.0.1",
-        "proxy-from-env": "1.1.0",
-        "rimraf": "3.0.2",
-        "tar-fs": "2.1.1",
-        "unbzip2-stream": "1.4.3",
-        "ws": "8.11.0"
-      },
-      "engines": {
-        "node": ">=14.1.0"
-      }
-    },
-    "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-      "dev": true,
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
-      }
     },
     "node_modules/lighthouse/node_modules/semver": {
       "version": "5.7.1",
@@ -3640,20 +3598,6 @@
           "url": "https://feross.org/support"
         }
       ]
-    },
-    "node_modules/quibble": {
-      "version": "0.6.15",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
-      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
-      "dev": true,
-      "dependencies": {
-        "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
-      },
-      "engines": {
-        "iojs": ">= 1.0.0",
-        "node": ">= 0.12.0"
-      }
     },
     "node_modules/quote": {
       "version": "0.4.0",
@@ -5862,7 +5806,8 @@
       "version": "0.0.1082910",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1082910.tgz",
       "integrity": "sha512-RqoZ2GmqaNxyx+99L/RemY5CkwG9D0WEfOKxekwCRXOGrDCep62ngezEJUVMq6rISYQ+085fJnWDQqGHlxVNww==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "diff": {
       "version": "5.0.0",
@@ -6782,9 +6727,9 @@
       }
     },
     "lighthouse": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.0.0.tgz",
-      "integrity": "sha512-q9N2+1eeywdP81MEifePk+qTxZg9dLb0zajaWI8foqqxG8QD3eF+z6oVMx8VFglOAJMofw+AaXG10vmeoY+dBQ==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/lighthouse/-/lighthouse-10.0.1.tgz",
+      "integrity": "sha512-vxHggvQPAx5ousLosVzWHTPJ+MpVYee+ojiP0r0ewq8cWAvnzLb6M2EieeBfjjm87shRaj0BB2puC8gFztwXXw==",
       "dev": true,
       "requires": {
         "@sentry/node": "^6.17.4",
@@ -6806,7 +6751,6 @@
         "parse-cache-control": "1.0.1",
         "ps-list": "^8.0.0",
         "puppeteer-core": "^19.6.0",
-        "quibble": "0.6.15",
         "robots-parser": "^3.0.0",
         "semver": "^5.3.0",
         "speedline-core": "^1.4.3",
@@ -6816,33 +6760,6 @@
         "yargs-parser": "^21.0.0"
       },
       "dependencies": {
-        "puppeteer-core": {
-          "version": "19.6.3",
-          "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-19.6.3.tgz",
-          "integrity": "sha512-8MbhioSlkDaHkmolpQf9Z7ui7jplFfOFTnN8d5kPsCazRRTNIH6/bVxPskn0v5Gh9oqOBlknw0eHH0/OBQAxpQ==",
-          "dev": true,
-          "requires": {
-            "cross-fetch": "3.1.5",
-            "debug": "4.3.4",
-            "devtools-protocol": "0.0.1082910",
-            "extract-zip": "2.0.1",
-            "https-proxy-agent": "5.0.1",
-            "proxy-from-env": "1.1.0",
-            "rimraf": "3.0.2",
-            "tar-fs": "2.1.1",
-            "unbzip2-stream": "1.4.3",
-            "ws": "8.11.0"
-          },
-          "dependencies": {
-            "ws": {
-              "version": "8.11.0",
-              "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-              "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
-              "dev": true,
-              "requires": {}
-            }
-          }
-        },
         "semver": {
           "version": "5.7.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -7456,16 +7373,6 @@
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
       "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
       "dev": true
-    },
-    "quibble": {
-      "version": "0.6.15",
-      "resolved": "https://registry.npmjs.org/quibble/-/quibble-0.6.15.tgz",
-      "integrity": "sha512-AKUMjlGPigm6slA3eXsTiCHg1ZRwzdsggUKCu8Ko6XyauPfkkBPOXbvdxwhPmC5GD/BtDXLEiPV9cV9xt+as1w==",
-      "dev": true,
-      "requires": {
-        "lodash": "^4.17.21",
-        "resolve": "^1.20.0"
-      }
     },
     "quote": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "eslint-config-prettier": "8.5.0",
     "eslint-plugin-prettier": "4.2.1",
     "eslint-plugin-tsdoc": "0.2.17",
-    "lighthouse": "^10.0.0",
+    "lighthouse": "^10.0.1",
     "mime": "3.0.0",
     "mocha": "10.1.0",
     "prettier": "2.7.1",
@@ -88,11 +88,6 @@
   "peerDependencies": {
     "puppeteer": ">=18.0.5",
     "lighthouse": ">=10.0.0"
-  },
-  "overrides": {
-    "lighthouse": {
-      "quibble": "0.6.15"
-    }
   },
   "peerDependenciesMeta": {
     "puppeteer": {


### PR DESCRIPTION
The 10.0.1 release removed quibble from package deps so we don't need the override anymore.