### PR TITLE
fix: find the svg owner element

### DIFF
--- a/src/PuppeteerRunnerExtension.ts
+++ b/src/PuppeteerRunnerExtension.ts
@@ -545,14 +545,20 @@ async function scrollIntoViewIfNeeded(
   if (intersectionTarget) {
     await waitForInViewport(intersectionTarget, timeout);
   }
+  await intersectionTarget.dispose();
+  if (intersectionTarget !== element) {
+    await element.dispose();
+  }
 }
 
 async function getOwnerSVGElement(
   handle: ElementHandle<SVGElement>
 ): Promise<ElementHandle<SVGSVGElement>> {
+  // If there is no ownerSVGElement, the element must be the top-level SVG
+  // element itself.
   return await handle.evaluateHandle((element) => {
     /* c8 ignore start */
-    return element.ownerSVGElement!;
+    return element.ownerSVGElement ?? (element as SVGSVGElement);
     /* c8 ignore stop */
   });
 }

--- a/test/runner.test.ts
+++ b/test/runner.test.ts
@@ -182,7 +182,7 @@ describe('Runner', () => {
     );
   });
 
-  it('should be able to replay click steps on SVG path elements', async () => {
+  it('should be able to replay click steps on SVG elements', async () => {
     const runner = await createRunner(
       {
         title: 'test',
@@ -194,6 +194,12 @@ describe('Runner', () => {
           {
             type: StepType.Click,
             selectors: ['svg > path'],
+            offsetX: 1,
+            offsetY: 1,
+          },
+          {
+            type: StepType.Click,
+            selectors: ['svg'],
             offsetX: 1,
             offsetY: 1,
           },


### PR DESCRIPTION
This PR fixes a bug where an svg owner is null if the target element is an svg element already.

Drive-by: noticed missing dispose calls.