### PR TITLE
feat: move `duration` to click attributes

### DIFF
--- a/src/PuppeteerStringifyExtension.ts
+++ b/src/PuppeteerStringifyExtension.ts
@@ -170,6 +170,9 @@ export class PuppeteerStringifyExtension extends StringifyExtension {
     this.#appendWaitForSelector(out, step);
     out.appendLine('await element.click({');
     out.appendLine(`  clickCount: 2,`);
+    if (step.duration) {
+      out.appendLine(`  delay: ${step.duration},`);
+    }
     if (step.button) {
       out.appendLine(`  button: '${mouseButtonMap.get(step.button)}',`);
     }

--- a/src/Schema.ts
+++ b/src/Schema.ts
@@ -127,6 +127,12 @@ export interface ClickAttributes {
    * to the center of the element
    */
   offsetY: number;
+  /**
+   * Delay (in ms) between the mouse up and mouse down of the click.
+   *
+   * @defaultValue `50`
+   */
+  duration?: number;
 }
 
 export interface DoubleClickStep extends ClickAttributes, StepWithSelectors {
@@ -135,11 +141,6 @@ export interface DoubleClickStep extends ClickAttributes, StepWithSelectors {
 
 export interface ClickStep extends ClickAttributes, StepWithSelectors {
   type: StepType.Click;
-  /**
-   * Delay (in ms) between the mouse up and mouse down of the click. Defaults to
-   * 50ms.
-   */
-  duration?: number;
 }
 
 export interface HoverStep extends StepWithSelectors {

--- a/src/SchemaUtils.ts
+++ b/src/SchemaUtils.ts
@@ -300,6 +300,7 @@ function parseClickAttributes(step: object): ClickAttributes {
   const attributes: ClickAttributes = {
     offsetX: parseNumber(step, 'offsetX'),
     offsetY: parseNumber(step, 'offsetY'),
+    duration: parseOptionalNumber(step, 'duration'),
   };
   const deviceType = parseOptionalString(step, 'deviceType');
   if (deviceType) {
@@ -331,7 +332,6 @@ function parseClickStep(step: object): ClickStep {
     ...parseStepWithSelectors(StepType.Click, step),
     ...parseClickAttributes(step),
     type: StepType.Click,
-    duration: parseOptionalNumber(step, 'duration'),
   };
 }
 


### PR DESCRIPTION
All clicks have a duration (even double clicks [it's the last click]) associated with them within Chrome. We should reflect that here.
