### PR TITLE
fix: access locators via a shortcut

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@puppeteer/replay",
-      "version": "2.12.0",
+      "version": "2.12.1",
       "license": "Apache-2.0",
       "dependencies": {
         "cli-table3": "0.6.3",
@@ -43,8 +43,8 @@
         "mime": "3.0.0",
         "mocha": "10.1.0",
         "prettier": "2.7.1",
-        "puppeteer": "20.7.4",
-        "puppeteer-core": "20.7.4",
+        "puppeteer": "20.8.0",
+        "puppeteer-core": "20.8.0",
         "rimraf": "3.0.2",
         "rollup": "3.2.2",
         "rollup-plugin-dts": "5.0.0",
@@ -60,7 +60,7 @@
       },
       "peerDependencies": {
         "lighthouse": ">=10.0.0",
-        "puppeteer": ">=20.7.3"
+        "puppeteer": ">=20.8.0"
       },
       "peerDependenciesMeta": {
         "lighthouse": {
@@ -414,9 +414,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/tar-stream": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.4.tgz",
-      "integrity": "sha512-IlHr7ZOW6XaVBCrSCokUJG4IqUuRcWW76B8XbrtCotbaDh6zVGE7WPCzaSz1CN+acFmWiwoa+cE4RZsom0RzXg==",
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.6.tgz",
+      "integrity": "sha512-B/UyjYwPpMBv+PaFSWAmtYjwdrlEaZQEhMIBFNC5oEG8lpiW8XjcSdmEaClj28ArfKScKHs2nshz3k2le6crsg==",
       "dev": true,
       "dependencies": {
         "b4a": "^1.6.4",
@@ -1812,15 +1812,15 @@
       }
     },
     "node_modules/degenerator": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-4.0.2.tgz",
-      "integrity": "sha512-HKwIFvZROUMfH3qI3gBpD61BYh7q3c3GXD5UGZzoVNJwVSYgZKvYl1fRMXc9ozoTxl/VZxKJ5v/bA+19tywFiw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-4.0.4.tgz",
+      "integrity": "sha512-MTZdZsuNxSBL92rsjx3VFWe57OpRlikyLbcx2B5Dmdv6oScqpMrvpY7zHLMymrUxo3U5+suPUMsNgW/+SZB1lg==",
       "dev": true,
       "dependencies": {
-        "ast-types": "^0.13.2",
-        "escodegen": "^1.8.1",
-        "esprima": "^4.0.0",
-        "vm2": "^3.9.17"
+        "ast-types": "^0.13.4",
+        "escodegen": "^1.14.3",
+        "esprima": "^4.0.1",
+        "vm2": "^3.9.19"
       },
       "engines": {
         "node": ">= 14"
@@ -3991,13 +3991,13 @@
       }
     },
     "node_modules/pac-resolver": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-6.0.1.tgz",
-      "integrity": "sha512-dg497MhVT7jZegPRuOScQ/z0aV/5WR0gTdRu1md+Irs9J9o+ls5jIuxjo1WfaTG+eQQkxyn5HMGvWK+w7EIBkQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/pac-resolver/-/pac-resolver-6.0.2.tgz",
+      "integrity": "sha512-EQpuJ2ifOjpZY5sg1Q1ZeAxvtLwR7Mj3RgY8cysPGbsRu3RBXyJFWxnMus9PScjxya/0LzvVDxNh/gl0eXBU4w==",
       "dev": true,
       "dependencies": {
-        "degenerator": "^4.0.1",
-        "ip": "^1.1.5",
+        "degenerator": "^4.0.4",
+        "ip": "^1.1.8",
         "netmask": "^2.0.2"
       },
       "engines": {
@@ -4254,29 +4254,29 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "20.7.4",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.7.4.tgz",
-      "integrity": "sha512-4JLZeRLXQAjQwWa6yv8cpjEgVapgrvDjBBcI/UCJ+EM6na6aR7hQFnQV4ffjFlUKPpvB2Y1vztVqOEhjfC+yUQ==",
+      "version": "20.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-20.8.0.tgz",
+      "integrity": "sha512-DnTwtQMUzWGkJYN3rvUW8y2LciFMnM0YR9cgwWmYmMLhUnYQw1XX+Q+5cAO8+AADglVuJCz0kaopd0lMI5j04g==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@puppeteer/browsers": "1.4.3",
         "cosmiconfig": "8.2.0",
-        "puppeteer-core": "20.7.4"
+        "puppeteer-core": "20.8.0"
       },
       "engines": {
         "node": ">=16.3.0"
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "20.7.4",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.7.4.tgz",
-      "integrity": "sha512-7YZ1LmTo+5yM9uBNFTMJpE+lJjcIoNjKVarsYIk7o5WhgQNI9o5XgiQK5f71y1vWwr7sT/eGG75HXAehjnTBTg==",
+      "version": "20.8.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-20.8.0.tgz",
+      "integrity": "sha512-sQcuH6nv9jnFiaaePk53+C0O9BaJP6OaPmYKqJ3sWhziThv6uaaosK49Kg3g1HUUEP9KYhbOhedPIUCXJSQUxw==",
       "dev": true,
       "dependencies": {
         "@puppeteer/browsers": "1.4.3",
         "chromium-bidi": "0.4.16",
-        "cross-fetch": "3.1.6",
+        "cross-fetch": "4.0.0",
         "debug": "4.3.4",
         "devtools-protocol": "0.0.1135028",
         "ws": "8.13.0"
@@ -4306,12 +4306,12 @@
       }
     },
     "node_modules/puppeteer-core/node_modules/cross-fetch": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.6.tgz",
-      "integrity": "sha512-riRvo06crlE8HiqOwIpQhxwdOk4fOeR7FVM/wXoxchFEqMNUjvbs3bfo4OTgMEMHzppd4DxFBDbyySj8Cv781g==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.0.0.tgz",
+      "integrity": "sha512-e4a5N8lVvuLgAWgnCrLr2PP0YyDOTHa9H/Rj54dirp61qXnNq46m82bRhNqIA5VccJtWBvPTFRV3TtvHUKPB1g==",
       "dev": true,
       "dependencies": {
-        "node-fetch": "^2.6.11"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
@@ -4321,9 +4321,9 @@
       "dev": true
     },
     "node_modules/puppeteer-core/node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -77,8 +77,8 @@
     "mime": "3.0.0",
     "mocha": "10.1.0",
     "prettier": "2.7.1",
-    "puppeteer": "20.7.4",
-    "puppeteer-core": "20.7.4",
+    "puppeteer": "20.8.0",
+    "puppeteer-core": "20.8.0",
     "rimraf": "3.0.2",
     "rollup": "3.2.2",
     "rollup-plugin-dts": "5.0.0",
@@ -91,7 +91,7 @@
   },
   "peerDependencies": {
     "lighthouse": ">=10.0.0",
-    "puppeteer": ">=20.7.3"
+    "puppeteer": ">=20.8.0"
   },
   "peerDependenciesMeta": {
     "puppeteer": {

--- a/src/PuppeteerRunnerExtension.ts
+++ b/src/PuppeteerRunnerExtension.ts
@@ -13,13 +13,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
  */
-import {
+import type {
   Browser,
   ElementHandle,
   Frame,
-  Page,
-  Locator,
   LocatorEmittedEvents,
+  Page,
 } from 'puppeteer';
 import { Frame as InternalFrame } from 'puppeteer-core/internal/common/Frame.js';
 import { CDPPage as InternalPage } from 'puppeteer-core/internal/common/Page.js';
@@ -119,18 +118,21 @@ export class PuppeteerRunnerExtension extends RunnerExtension {
     const startWaitingForEvents = () => {
       assertedEventsPromise = waitForEvents(localFrame, step, timeout);
     };
+    const locatorRace = (this.page as unknown as InternalPage).locatorRace;
 
     switch (step.type) {
       case StepType.DoubleClick:
-        await Locator.race(
+        await locatorRace(
           step.selectors.map((selector) => {
-            return targetPageOrFrame.locator(
-              selectorToPElementSelector(selector)
-            );
+            return (
+              targetPageOrFrame as unknown as InternalPage | InternalFrame
+            ).locator(selectorToPElementSelector(selector));
           })
         )
           .setTimeout(timeout)
-          .on(LocatorEmittedEvents.Action, () => startWaitingForEvents())
+          .on('action' as LocatorEmittedEvents.Action, () =>
+            startWaitingForEvents()
+          )
           .click({
             count: 2,
             button: step.button && mouseButtonMap.get(step.button),
@@ -142,15 +144,17 @@ export class PuppeteerRunnerExtension extends RunnerExtension {
           });
         break;
       case StepType.Click:
-        await Locator.race(
+        await locatorRace(
           step.selectors.map((selector) => {
-            return targetPageOrFrame.locator(
-              selectorToPElementSelector(selector)
-            );
+            return (
+              targetPageOrFrame as unknown as InternalPage | InternalFrame
+            ).locator(selectorToPElementSelector(selector));
           })
         )
           .setTimeout(timeout)
-          .on(LocatorEmittedEvents.Action, () => startWaitingForEvents())
+          .on('action' as LocatorEmittedEvents.Action, () =>
+            startWaitingForEvents()
+          )
           .click({
             delay: step.duration,
             button: step.button && mouseButtonMap.get(step.button),
@@ -161,15 +165,17 @@ export class PuppeteerRunnerExtension extends RunnerExtension {
           });
         break;
       case StepType.Hover:
-        await Locator.race(
+        await locatorRace(
           step.selectors.map((selector) => {
-            return targetPageOrFrame.locator(
-              selectorToPElementSelector(selector)
-            );
+            return (
+              targetPageOrFrame as unknown as InternalPage | InternalFrame
+            ).locator(selectorToPElementSelector(selector));
           })
         )
           .setTimeout(timeout)
-          .on(LocatorEmittedEvents.Action, () => startWaitingForEvents())
+          .on('action' as LocatorEmittedEvents.Action, () =>
+            startWaitingForEvents()
+          )
           .hover();
         break;
       case StepType.EmulateNetworkConditions:
@@ -201,14 +207,16 @@ export class PuppeteerRunnerExtension extends RunnerExtension {
         }
         break;
       case StepType.Change:
-        await Locator.race(
+        await locatorRace(
           step.selectors.map((selector) => {
-            return targetPageOrFrame.locator(
-              selectorToPElementSelector(selector)
-            );
+            return (
+              targetPageOrFrame as unknown as InternalPage | InternalFrame
+            ).locator(selectorToPElementSelector(selector));
           })
         )
-          .on(LocatorEmittedEvents.Action, () => startWaitingForEvents())
+          .on('action' as LocatorEmittedEvents.Action, () =>
+            startWaitingForEvents()
+          )
           .setTimeout(timeout)
           .fill(step.value);
         break;
@@ -221,14 +229,16 @@ export class PuppeteerRunnerExtension extends RunnerExtension {
       }
       case StepType.Scroll: {
         if ('selectors' in step) {
-          await Locator.race(
+          await locatorRace(
             step.selectors.map((selector) => {
-              return targetPageOrFrame.locator(
-                selectorToPElementSelector(selector)
-              );
+              return (
+                targetPageOrFrame as unknown as InternalPage | InternalFrame
+              ).locator(selectorToPElementSelector(selector));
             })
           )
-            .on(LocatorEmittedEvents.Action, () => startWaitingForEvents())
+            .on('action' as LocatorEmittedEvents.Action, () =>
+              startWaitingForEvents()
+            )
             .setTimeout(timeout)
             .scroll({
               scrollLeft: step.x || 0,


### PR DESCRIPTION
Note that the Stringify extension can still use Locators as envisioned in the generated code and only the Runner extension needs to avoid the static dependency on Puppeteer.